### PR TITLE
fix(schema): Use default field resolver if none is specified

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,9 +42,11 @@ function wrapResolverInMiddleware(
   middleware: IMiddlewareFunction,
 ): GraphQLFieldResolver<any, any> {
   return (parent, args, ctx, info) => {
+    const resolveFn = resolver || defaultFieldResolver
+
     return middleware(
       (_parent = parent, _args = args, _ctx = ctx, _info = info) =>
-        (resolver || defaultFieldResolver)(_parent, _args, _ctx, _info),
+        resolveFn(_parent, _args, _ctx, _info),
       parent,
       args,
       ctx,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  defaultFieldResolver,
   GraphQLSchema,
   getNamedType,
   getNullableType,
@@ -43,7 +44,7 @@ function wrapResolverInMiddleware(
   return (parent, args, ctx, info) => {
     return middleware(
       (_parent = parent, _args = args, _ctx = ctx, _info = info) =>
-        resolver(_parent, _args, _ctx, _info),
+        (resolver || defaultFieldResolver)(_parent, _args, _ctx, _info),
       parent,
       args,
       ctx,

--- a/test.js
+++ b/test.js
@@ -13,6 +13,7 @@ const typeDefs = `
     afterNothing: String!
     null: String
     nested: Nothing!
+    resolverless: Resolverless!
   }
 
   type Mutation {
@@ -26,6 +27,10 @@ const typeDefs = `
 
   type Nothing {
     nothing: String!
+  }
+
+  type Resolverless {
+    someData: String!
   }
 
   schema {
@@ -42,6 +47,7 @@ const resolvers = {
     afterNothing: () => 'after',
     null: () => null,
     nested: () => ({}),
+    resolverless: () => ({ someData: 'data' }),
   },
   Mutation: {
     before: async (parent, { arg }, ctx, info) => arg,
@@ -424,6 +430,28 @@ test('Schema middleware - Mutation after', async t => {
       afterNothing: 'changed',
       null: 'changed',
       nested: { nothing: 'changed' },
+    },
+  })
+})
+
+test('Schema middleware - Uses default field resolver', async t => {
+  const schema = getSchema()
+  const schemaWithMiddleware = applyMiddleware(schema, schemaMiddlewareBefore)
+
+  const query = `
+    query {
+      resolverless {
+        someData
+      }
+    }
+  `
+  const res = await graphql(schemaWithMiddleware, query)
+
+  t.deepEqual(res, {
+    data: {
+      resolverless: {
+        someData: 'data',
+      },
     },
   })
 })


### PR DESCRIPTION
This basically replicates the default graphql-js behaviour. Without this the middleware ends up throwing `TypeError: resolver is not a function`.