### PR TITLE
Add an API to expand a single middleware function to cover all non-default resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ function applyMiddleware(
   schema: GraphQLSchema,
   ...middleware: (IMiddleware | MiddlewareGenerator)[]
 ): GraphQLSchema
+
+/**
+ * Applies middleware to a schema like `applyMiddleware` but only applies the
+ * middleware to fields that have non-default resolvers. This method can be
+ * useful if you want to report performance of only non-trivial methods.
+ */
+function applyMiddlewareToDeclaredResolvers(
+  schema: GraphQLSchema,
+  ...middleware: (IMiddleware | MiddlewareGenerator)[]
+): GraphQLSchema
 ```
 
 ### Middleware Generator

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,7 +314,11 @@ export function applyMiddleware<TSource = any, TContext = any, TArgs = any>(
     | IMiddleware<TSource, TContext, TArgs>
     | MiddlewareGenerator<TSource, TContext, TArgs>)[]
 ): GraphQLSchema {
-  return applyMiddlewareWithOptions(schema, {}, ...middlewares)
+  return applyMiddlewareWithOptions(
+    schema,
+    { onlyDeclaredResolvers: false },
+    ...middlewares,
+  )
 }
 
 export function applyMiddlewareToDeclaredResolvers<

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,3 +43,7 @@ export declare type IMiddlewareGenerator<
 export declare type IMiddleware<TSource = any, TContext = any, TArgs = any> =
   | IMiddlewareFunction<TSource, TContext, TArgs>
   | IMiddlewareTypeMap<TSource, TContext, TArgs>
+
+export declare type IApplyOptions = {
+  onlyDeclaredResolvers?: boolean
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,5 +45,5 @@ export declare type IMiddleware<TSource = any, TContext = any, TArgs = any> =
   | IMiddlewareTypeMap<TSource, TContext, TArgs>
 
 export declare type IApplyOptions = {
-  onlyDeclaredResolvers?: boolean
+  onlyDeclaredResolvers: boolean
 }

--- a/test.js
+++ b/test.js
@@ -765,7 +765,7 @@ test('applyMiddlewareToDeclaredResolvers - applies middleware to all but default
       resolverless {
         someData
       }
-      afterNothing
+      after
     }
   `
   const res = await graphql(schemaWithMiddleware, query)
@@ -775,7 +775,7 @@ test('applyMiddlewareToDeclaredResolvers - applies middleware to all but default
       resolverless: {
         someData: 'data',
       },
-      afterNothing: '',
+      after: '',
     },
   })
 })

--- a/test.js
+++ b/test.js
@@ -2,7 +2,12 @@ import test from 'ava'
 import { graphql, subscribe, parse } from 'graphql'
 import { makeExecutableSchema } from 'graphql-tools'
 import { $$asyncIterator } from 'iterall'
-import { applyMiddleware, middleware, MiddlewareError } from './dist'
+import {
+  applyMiddleware,
+  middleware,
+  applyMiddlewareToDeclaredResolvers,
+  MiddlewareError,
+} from './dist'
 
 // Setup ---------------------------------------------------------------------
 
@@ -154,6 +159,14 @@ const schemaMiddlewareBefore = async (resolve, parent, args, context, info) => {
 const schemaMiddlewareAfter = async (resolve, parent, args, context, info) => {
   const res = resolve()
   return 'changed'
+}
+
+const emptyStringMiddleware = async (resolve, parent, args, context, info) => {
+  if (/^String!?$/.test(info.returnType)) {
+    return ''
+  } else {
+    return resolve()
+  }
 }
 
 // Middleware Validation
@@ -738,4 +751,31 @@ test('Middleware with generator', async t => {
   const res = await graphql(schemaWithMiddleware, query)
 
   t.is(res.data.test, 'pass')
+})
+
+test('applyMiddlewareToDeclaredResolvers - applies middleware to all but default resolvers', async t => {
+  const schema = getSchema()
+  const schemaWithMiddleware = applyMiddlewareToDeclaredResolvers(
+    schema,
+    emptyStringMiddleware,
+  )
+
+  const query = `
+    query {
+      resolverless {
+        someData
+      }
+      afterNothing
+    }
+  `
+  const res = await graphql(schemaWithMiddleware, query)
+
+  t.deepEqual(res, {
+    data: {
+      resolverless: {
+        someData: 'data',
+      },
+      afterNothing: '',
+    },
+  })
 })


### PR DESCRIPTION
I introduced a new method that expands a single IMiddlewareFunction into a IMiddlewareTypeMap that covers just the non-default resovers in the schema.  I took this approach for a couple of reasons:

1. It follow a more functional programming style, which I liked and leads to (2) below
2. It does not require any changes to existing logic. The existing method does not need to be complicated with an extra/optional options argument or new types.

Fixes #12 