### PR TITLE
fix(docs): Add plugins section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ const server = new GraphQLServer({
 server.start(() => console.log('Server is running on localhost:4000'))
 ```
 
-### Examples
+## Awesome Plugins [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
+* [graphql-middleware-apollo-upload-server](http://github.com/homeroom-live/graphql-middleware-apollo-upload-server) - Uploading files is hard, that's why this package manages it for you!
+* [graphql-shield](https://github.com/maticzav/graphql-shield) - Permissions as another layer of abstraction.
+* [graphql-middleware-sentry](https://github.com/maticzav/graphql-middleware-sentry) - Report your server errors to Sentry.
+* [graphql-middleware-forward-binding](https://github.com/maticzav/graphql-middleware-forward-binding) - GraphQL Binding forwardTo plugin for GraphQL Middleware.
 
 ## API
 


### PR DESCRIPTION
Fixes #11 , we should use `graphql-middleware` as a preposition but it's not a must. 